### PR TITLE
Add 6-hour transient cache for destination fetching

### DIFF
--- a/assets/js/license-management-outbound.js
+++ b/assets/js/license-management-outbound.js
@@ -447,8 +447,52 @@ jQuery(function ($) {
             alert('Network error occurred. Please try again.');
         });
     });
- 
-    
 
-    
+    // =================== DESTINATION CACHE REFRESH ===================
+    $('#refresh-destinations-btn').on('click', function(e) {
+        e.preventDefault();
+
+        var $button = $(this);
+        var originalText = $button.text();
+        var originalHtml = $button.html();
+
+        // Show loading state
+        $button.html('<span class="spinner" style="display:inline-block;margin-right:5px;"></span>Refreshing...').prop('disabled', true);
+
+        $.post(ajaxurl, {
+            action: 'refresh_destinations_cache',
+            nonce: licenseData.nonce
+        }, function(response) {
+            $button.html(originalHtml).prop('disabled', false);
+
+            if (response.success) {
+                var newOptions = response.data.options;
+
+                // Clear existing options (keeping the placeholder)
+                var $select = $('#destination_select');
+                $select.find('option:not(:first)').remove();
+
+                // Add new options
+                newOptions.forEach(function(option) {
+                    $select.append(
+                        $('<option></option>')
+                            .attr('value', option.id)
+                            .attr('data-text', option.text)
+                            .text(option.text)
+                    );
+                });
+
+                // Refresh Select2
+                $select.trigger('change');
+
+                alert('Destinations refreshed successfully!');
+            } else {
+                alert('Error: ' + (response.data.message || 'Failed to refresh destinations'));
+            }
+        }).fail(function() {
+            $button.html(originalHtml).prop('disabled', false);
+            alert('Network error occurred. Please try again.');
+        });
+    });
+
 });

--- a/src/API/FlourishAPI.php
+++ b/src/API/FlourishAPI.php
@@ -497,45 +497,78 @@ class FlourishAPI
         return false;
     }
 
-     public function fetch_destination_by_facility_name()
-{
-    $all_destinations = [];
-    $offset = 0;
-    $limit = self::API_LIMIT;
-    
-    do {
-        // Fix the API URL construction - there was a syntax error in your original code
-        $api_url = $this->url . "/external/api/v1/destinations?offset=" . $offset . "&limit=" . $limit;
-        $headers = $this->get_headers();
-        
-        // Use the HttpRequestHelper for the API call
-        try {
-            $response_http = HttpRequestHelper::make_request($api_url, 'GET', $headers);
-            $response_data = HttpRequestHelper::validate_response($response_http);
-        } catch (\Exception $e) {
-            throw new \Exception("Error fetching destination by facility_name: " . $e->getMessage());
+    /**
+     * Generate cache key for destinations
+     * Scoped per API URL to avoid collisions if multiple Flourish accounts are configured
+     *
+     * @return string The cache key
+     */
+    private function get_destination_cache_key() {
+        return 'flourish_destinations_' . md5( $this->url );
+    }
+
+    /**
+     * Clear the destination cache
+     * Can be called manually to force a refresh
+     */
+    public function clear_destination_cache() {
+        delete_transient( $this->get_destination_cache_key() );
+    }
+
+    public function fetch_destination_by_facility_name()
+    {
+        // Check for cached result first (6 hour TTL)
+        $cache_key = $this->get_destination_cache_key();
+        $cached_destinations = get_transient( $cache_key );
+
+        if ( false !== $cached_destinations ) {
+            return $cached_destinations;
         }
-        
-        // Check if we got data
-        if (isset($response_data['data']) && is_array($response_data['data']) && count($response_data['data'])) {
-            // Merge current batch with all destinations
-            $all_destinations = array_merge($all_destinations, $response_data['data']);
-            
-            // If we got less than the limit, we've reached the end
-            $has_more_data = count($response_data['data']) == $limit;
-            
-            // Increment offset for next batch
-            $offset += $limit;
-        } else {
-            // No more data
-            $has_more_data = false;
+
+        $all_destinations = [];
+        $offset = 0;
+        $limit = self::API_LIMIT;
+
+        do {
+            // Fix the API URL construction - there was a syntax error in your original code
+            $api_url = $this->url . "/external/api/v1/destinations?offset=" . $offset . "&limit=" . $limit;
+            $headers = $this->get_headers();
+
+            // Use the HttpRequestHelper for the API call
+            try {
+                $response_http = HttpRequestHelper::make_request($api_url, 'GET', $headers);
+                $response_data = HttpRequestHelper::validate_response($response_http);
+            } catch (\Exception $e) {
+                throw new \Exception("Error fetching destination by facility_name: " . $e->getMessage());
+            }
+
+            // Check if we got data
+            if (isset($response_data['data']) && is_array($response_data['data']) && count($response_data['data'])) {
+                // Merge current batch with all destinations
+                $all_destinations = array_merge($all_destinations, $response_data['data']);
+
+                // If we got less than the limit, we've reached the end
+                $has_more_data = count($response_data['data']) == $limit;
+
+                // Increment offset for next batch
+                $offset += $limit;
+            } else {
+                // No more data
+                $has_more_data = false;
+            }
+
+        } while ($has_more_data);
+
+        $result = count($all_destinations) > 0 ? $all_destinations : false;
+
+        // Cache the result for 6 hours (21600 seconds)
+        // Only cache successful responses that return an array
+        if ( is_array( $result ) ) {
+            set_transient( $cache_key, $result, 6 * HOUR_IN_SECONDS );
         }
-        
-    } while ($has_more_data);
-    
-    // Return all destinations or false if none found
-    return count($all_destinations) > 0 ? $all_destinations : false;
-}
+
+        return $result;
+    }
 
     public function fetch_uoms()
     {

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -474,9 +474,17 @@ class SettingsPage
         $sanitized_settings['flourish_order_status'] = !empty($settings['flourish_order_status']) ? sanitize_text_field($settings['flourish_order_status']) : 'created';
        // Handle WooCommerce order status for outbound orders
         $sanitized_settings['woocommerce_order_status'] = !empty($settings['woocommerce_order_status']) ? sanitize_text_field($settings['woocommerce_order_status']) : 'draft';
-  
+
         // Default to production API
         $sanitized_settings['url'] = !empty($settings['url']) ? esc_url_raw($settings['url']) : 'https://app.flourishsoftware.com';
+
+        // Clear destination cache if API credentials change
+        $old_url = $this->existing_settings['url'] ?? '';
+        $old_api_key = $this->existing_settings['api_key'] ?? '';
+        if ($sanitized_settings['url'] !== $old_url || $sanitized_settings['api_key'] !== $old_api_key) {
+            delete_transient('flourish_destinations_' . md5($old_url));
+            delete_transient('flourish_destinations_' . md5($sanitized_settings['url']));
+        }
 
         // Sanitize the brands
         $sanitized_settings['brands'] = !empty($settings['brands']) ? array_map('sanitize_text_field', $settings['brands']) : [];

--- a/src/Admin/WoocommerceOutboundSettings.php
+++ b/src/Admin/WoocommerceOutboundSettings.php
@@ -21,8 +21,9 @@ class WoocommerceOutboundSettings
         // Hook to add license fields in the user profile
         add_action( 'show_user_profile', [ $this, 'add_license_field_to_user_edit' ] );
         add_action( 'edit_user_profile', [ $this, 'add_license_field_to_user_edit' ] ); 
-        add_action('wp_ajax_update_user_destinations', [$this, 'update_user_destinations_callback']); 
-        add_action('wp_ajax_update_destination_selection_toggle', [$this, 'update_destination_selection_toggle_callback']); 
+        add_action('wp_ajax_update_user_destinations', [$this, 'update_user_destinations_callback']);
+        add_action('wp_ajax_update_destination_selection_toggle', [$this, 'update_destination_selection_toggle_callback']);
+        add_action('wp_ajax_refresh_destinations_cache', [$this, 'refresh_destinations_cache_callback']);
         // Add this AJAX hook to your register_hooks() method:
         add_action('wp_ajax_toggle_sales_rep_management', [$this, 'toggle_sales_rep_management_callback']);
         // Sales Rep Management AJAX hooks
@@ -302,7 +303,65 @@ public function update_user_sales_reps_callback() {
         wp_send_json_error(['message' => 'Error updating destinations: ' . $e->getMessage()]);
     }
 }
- 
+
+    /**
+     * Refresh destination cache and return updated destination list via AJAX
+     */
+    public function refresh_destinations_cache_callback() {
+        // Check nonce
+        if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'license_management_nonce')) {
+            wp_send_json_error(['message' => 'Invalid nonce']);
+            return;
+        }
+
+        // Check user capabilities
+        if (!current_user_can('manage_woocommerce')) {
+            wp_send_json_error(['message' => 'Insufficient permissions']);
+            return;
+        }
+
+        try {
+            // Get API credentials
+            $api_key = $this->existing_settings['api_key'] ?? '';
+            $url = $this->existing_settings['url'] ?? '';
+            $facility_id = $this->existing_settings['facility_id'] ?? '';
+
+            if (empty($api_key) || empty($url) || empty($facility_id)) {
+                wp_send_json_error(['message' => 'API credentials not configured']);
+                return;
+            }
+
+            // Initialize API and clear cache
+            $flourish_api = new FlourishAPI($api_key, $url, $facility_id);
+            $flourish_api->clear_destination_cache();
+
+            // Fetch fresh destinations
+            $destination_options = $flourish_api->get_destination_options();
+
+            if (empty($destination_options)) {
+                wp_send_json_error(['message' => 'No destinations available from API']);
+                return;
+            }
+
+            // Format response for Select2
+            $options = [];
+            foreach ($destination_options as $id => $display_text) {
+                $options[] = [
+                    'id' => $id,
+                    'text' => $display_text
+                ];
+            }
+
+            wp_send_json_success([
+                'message' => 'Destinations refreshed successfully',
+                'options' => $options
+            ]);
+        } catch (Exception $e) {
+            error_log('Error refreshing destinations: ' . $e->getMessage());
+            wp_send_json_error(['message' => 'Error refreshing destinations: ' . $e->getMessage()]);
+        }
+    }
+
         /**
      * Get sales reps from Flourish API - sorted alphabetically
      */
@@ -429,9 +488,12 @@ public function update_user_sales_reps_callback() {
                                 </option>
                             <?php endforeach; ?>
                         </select>
+                        <button type="button" id="refresh-destinations-btn" class="button" style="margin-left: 10px;">
+                            <?php esc_html_e('Refresh Destinations', 'woocommerce'); ?>
+                        </button>
                     </div>
                     <p class="description">
-                        <?php 
+                        <?php
                         if (empty($destination_options)) {
                             esc_html_e('No destinations available from API.', 'woocommerce');
                         } else {


### PR DESCRIPTION
Implement WordPress transient caching for the destination list from Flourish API to reduce API calls and improve page load performance. Destinations are cached for 6 hours with a manual "Refresh Destinations" button for immediate updates when needed.

Changes:
- FlourishAPI: Add get_destination_cache_key(), clear_destination_cache(), and transient caching logic to fetch_destination_by_facility_name()
- WoocommerceOutboundSettings: Add refresh button and AJAX handler to bust cache and fetch fresh destinations without page reload
- SettingsPage: Clear destination cache when API credentials change
- license-management-outbound.js: Add click handler for refresh button with loading state and Select2 option updates

Cache key is scoped per API URL to support multiple Flourish accounts on one site. TTL: 6 hours (HOUR_IN_SECONDS constant)